### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v2.5.0
         with:
           node-version: 12
 
@@ -30,7 +30,7 @@ jobs:
         run: npm install
 
       - name: Setup BATS
-        uses: mig4/setup-bats@v1
+        uses: mig4/setup-bats@v1.2.0
         with:
           bats-version: 1.2.1
 

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Cancel
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           workflow_id: 'build.yml'
           access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Git
         run: |
@@ -36,7 +36,7 @@ jobs:
           GIT_EMAIL: ${{ secrets.CI_USER_GIT_EMAIL }}
 
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.5.0
         with:
           java-version: 11
           distribution: 'adopt'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[mig4/setup-bats](https://github.com/mig4/setup-bats)** published a new release [v1.2.0](https://github.com/mig4/setup-bats/releases/tag/v1.2.0) on 2020-11-01T12:58:58Z
* **[styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)** published a new release [0.9.1](https://github.com/styfle/cancel-workflow-action/releases/tag/0.9.1) on 2021-07-29T20:59:53Z
* **[gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action)** published a new release [v1.0.4](https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.4) on 2021-05-28T13:42:22Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v2.5.0](https://github.com/actions/setup-node/releases/tag/v2.5.0) on 2021-11-29T11:04:48Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v2.5.0](https://github.com/actions/setup-java/releases/tag/v2.5.0) on 2021-12-21T10:41:00Z
